### PR TITLE
Unify main.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - 'ansible-playbook -i localhost, -c local tests/test.yml --diff --verbose'
 
   # Detect idempotence failure.
-  - 'tail -n 1 ansible.log | grep -Eq "changed=0 +unreachable=0 +failed=0"'
+  - 'tail -n 5 ansible.log | grep -Eq "changed=0 +unreachable=0 +failed=0"'
 
 notifications:
   webhooks: 'https://galaxy.ansible.com/api/v1/notifications/'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,5 @@
 ---
 
-- name: Daemon reload
-  command: 'systemctl daemon-reload'
-
 - name: Restart nova compute
   service:
     name: '{{ openstack_nova_compute_service }}'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -6,6 +6,8 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart nova compute
   with_items:
     # Messaging
     - section: DEFAULT
@@ -107,8 +109,6 @@
     - section: oslo_concurrency
       option: lock_path
       value: /var/lib/nova/tmp
-  notify:
-    - Restart nova compute
 
 - name: Configure nova compute (2)
   ini_file:
@@ -116,26 +116,10 @@
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
+  notify:
+    - Restart nova compute
   with_items:
     # Libvirt
     - section: libvirt
       option: virt_type
       value: '{{ openstack_nova_compute_nova_virt_type }}'
-  notify:
-    - Restart nova compute
-
-- name: Start libvirtd
-  service:
-    name: '{{ openstack_nova_compute_libvirt_service }}'
-    state: started
-
-# Changing to 'simple' type to prevent hard dependency on other roles
-# See: http://lists.openstack.org/pipermail/openstack-dev/2015-December/083095.html
-- name: Fix systemd type
-  lineinfile:
-    dest: '/usr/lib/systemd/system/openstack-nova-compute.service'
-    regexp: '^Type=notify$'
-    line: 'Type=simple'
-    backrefs: True
-  when: ansible_os_family == 'RedHat'
-  notify: Daemon reload

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -2,20 +2,12 @@
 
 - name: Set service facts
   set_fact:
-    openstack_nova_compute_service: nova-compute
+    openstack_nova_compute_libvirt_service: 'libvirt-bin'
+    openstack_nova_compute_service: 'nova-compute'
   when: ansible_os_family == 'Debian'
 
 - name: Set service facts
   set_fact:
-    openstack_nova_compute_service: openstack-nova-compute.service
-  when: ansible_os_family == 'RedHat'
-
-- name: Set service facts
-  set_fact:
-    openstack_nova_compute_libvirt_service: libvirt-bin
-  when: ansible_os_family == 'Debian'
-
-- name: Set service facts
-  set_fact:
-    openstack_nova_compute_libvirt_service: libvirtd.service
+    openstack_nova_compute_libvirt_service: 'libvirtd.service'
+    openstack_nova_compute_service: 'openstack-nova-compute.service'
   when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 
+- include: facts.yml
+
+- include: packages_redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: packages_debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include: configuration.yml
+
+- include: services.yml
+
 - meta: flush_handlers
 
-- include: facts.yml
-- include: packages.yml
-- include: configuration.yml
-- meta: flush_handlers
 - include: sanitycheck.yml

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,7 +1,0 @@
----
-
-- include: packages_redhat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: packages_debian.yml
-  when: ansible_os_family == 'Debian'

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,31 @@
+---
+
+- block:
+    - name: 'Create drop-in directory for openstack-nova-compute.service'
+      file:
+        path: '/etc/systemd/system/openstack-nova-compute.service.d'
+        state: directory
+
+    # Changing to 'simple' type to prevent hard dependency on other roles
+    # See: http://lists.openstack.org/pipermail/openstack-dev/2015-December/083095.html
+    - name: 'Fix systemd type for openstack-nova-compute.service'
+      copy:
+        content: |
+          [Service]
+          Type=simple
+        dest: '/etc/systemd/system/openstack-nova-compute.service.d/type.conf'
+      register: openstack_nova_compute_service_d_type_conf
+
+    - name: 'Reload systemd manager configuration'
+      command: 'systemctl daemon-reload'
+      when: openstack_nova_compute_service_d_type_conf|changed
+  when: ansible_os_family == 'RedHat'
+
+- name: 'Start and enable services'
+  service:
+    enabled: True
+    name: '{{ item }}'
+    state: started
+  with_items:
+    - '{{ openstack_nova_compute_libvirt_service }}'
+    - '{{ openstack_nova_compute_service }}'

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -9,4 +9,3 @@
 - src: 'https://github.com/openstack-ansible-galaxy/rabbitmq.git'
 
 - src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
-  version: 'origin/features/mitaka'


### PR DESCRIPTION
Unify `main.yml` to a standard set of includes, with improved service
handling and fix for systemd service unit type.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
