### PR TITLE
No nova-compute.conf for RDO

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -112,7 +112,7 @@
 
 - name: Configure nova compute (2)
   ini_file:
-    dest: /etc/nova/nova-compute.conf
+    dest: '{{ openstack_nova_compute_compute_conf }}'
     section: '{{ item.section }}'
     option: '{{ item.option }}'
     value: '{{ item.value }}'
@@ -123,16 +123,3 @@
     - section: libvirt
       option: virt_type
       value: '{{ openstack_nova_compute_nova_virt_type }}'
-    # VNC
-    - section: DEFAULT
-      option: vncserver_listen
-      value: 0.0.0.0
-    - section: DEFAULT
-      option: vncserver_proxyclient_address
-      value: '{{ openstack_nova_compute_vncserver_proxyclient_address }}'
-    - section: DEFAULT
-      option: novncproxy_base_url
-      value: '{{ openstack_nova_compute_novncproxy_base_url }}'
-    - section: DEFAULT
-      option: compute_driver
-      value: 'libvirt.LibvirtDriver'

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,13 +1,15 @@
 ---
 
-- name: Set service facts
+- name: Set facts
   set_fact:
+    openstack_nova_compute_compute_conf: '/etc/nova/nova-compute.conf'
     openstack_nova_compute_libvirt_service: 'libvirt-bin'
     openstack_nova_compute_service: 'nova-compute'
   when: ansible_os_family == 'Debian'
 
-- name: Set service facts
+- name: Set facts
   set_fact:
+    openstack_nova_compute_compute_conf: '/etc/nova/nova.conf'
     openstack_nova_compute_libvirt_service: 'libvirtd.service'
     openstack_nova_compute_service: 'openstack-nova-compute.service'
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
RDO doesn't have a dedicated configuration file for `nova-compute`
service, need to use `nova.conf` for `nova-compute` service as well.
Also, removing deprecated configurations.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>